### PR TITLE
Fix edrv8111

### DIFF
--- a/stack/src/kernel/edrv/edrv-8111.c
+++ b/stack/src/kernel/edrv/edrv-8111.c
@@ -131,7 +131,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define EDRV_MASTER_DISABLE_TIMEOUT                     90                                          // in ms, max wait time for MAC reset
 #define EDRV_LINK_UP_TIMEOUT                            3000                                        // in ms, max wait time for Phy reset
 #define EDRV_DIAG_DUMP_TIMEOUT                          10                                          // in ms, max wait time for dump tally counter to dump data
-#define EDRV_PHY_UP_WAIT_TIME                           5000                                        // in ms, max wait time for Phy to be up
+#define EDRV_PHY_UP_WAIT_TIME                           500                                         // in ms, max wait time for Phy to be up
 #define EDRV_PHY_LINK_CHANGE_WAIT_TIME                  20                                          // in ms, wait time for Phy state change
 
 // Register read write functions

--- a/stack/src/kernel/edrv/edrv-8111.c
+++ b/stack/src/kernel/edrv/edrv-8111.c
@@ -98,7 +98,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifndef EDRV_MAX_TX_DESCS
-#define EDRV_MAX_TX_DESCS                               16                                          // max no. of tx descriptors to be used
+#define EDRV_MAX_TX_DESCS                               64                                          // max no. of tx descriptors to be used
 #define EDRV_TX_DESC_MASK                               (EDRV_MAX_TX_DESCS - 1)
 #endif
 


### PR DESCRIPTION
[TASK] Decreased the PHY up wait time in 8111 edrv

- Decreased the PHY up wait time to 500ms to reduce the
 delay in the 8111 edrv shutdown process.



[FIX] No free Tx descriptor in 8111 edrv

- Increased default Tx descriptor to 64 to enable the big
and fast network configurations.

