### PR TITLE
[FIX] Fix  pcap driver crash in demo apps

### DIFF
--- a/apps/demo_mn_console/src/main.c
+++ b/apps/demo_mn_console/src/main.c
@@ -195,7 +195,8 @@ static tOplkError initPowerlink(UINT32 cycleLen_p, char* pszCdcFileName_p,
     printf("Initializing openPOWERLINK stack...\n");
 
 #if defined(CONFIG_USE_PCAP)
-    selectPcapDevice(devName);
+    if (selectPcapDevice(devName) != 0)
+		return -1;
 #endif
 
     memset(&initParam, 0, sizeof(initParam));


### PR DESCRIPTION
- If the chosen pcap interface is out of range while running the linux User space application,
  driver crashes. Handled the crash by using a return value.

Signed-off-by: Avinash Alfred <avinash.a@kalycito.com>