### PR TITLE
[FIX] AMNI reception handling in DLL with RMN feature

### DIFF
--- a/stack/src/kernel/dll/dllkframe.c
+++ b/stack/src/kernel/dll/dllkframe.c
@@ -2175,25 +2175,30 @@ static tOplkError processReceivedAmni(tEdrvRxBuffer* pRxBuffer_p, tNmtState nmtS
     event.pEventArg = &nodeId;
     ret = eventk_postEvent(&event);
 
-    if (!NMT_IF_ACTIVE(nmtState_p))
-    {   // not in POWERLINK mode
+    if (!NMT_IF_ACTIVE_CN(nmtState_p))
+    {   // not a Standby Managing Node
         return ret;
     }
 
     // reprogram timer
     if (dllkInstance_g.fRedundancy)
     {
-        if ((nmtState_p == kNmtCsPreOperational1) ||
-            (nmtState_p == kNmtMsPreOperational1))
+        if (nmtState_p == kNmtCsPreOperational1)
         {
             hrestimer_modifyTimer(&dllkInstance_g.timerHdlSwitchOver,
                                   dllkInstance_g.dllConfigParam.reducedSwitchOverTimeMn * 1000ULL,
                                   dllk_cbTimerSwitchOver, 0L, FALSE);
         }
-        else
+        else if (nmtState_p == kNmtCsOperational)
         {
             hrestimer_modifyTimer(&dllkInstance_g.timerHdlSwitchOver,
                                   dllkInstance_g.dllConfigParam.switchOverTimeMn * 1000ULL,
+                                  dllk_cbTimerSwitchOver, 0L, FALSE);
+        }
+        else
+        {
+            hrestimer_modifyTimer(&dllkInstance_g.timerHdlSwitchOver,
+                                  dllkInstance_g.dllConfigParam.delayedSwitchOverTimeMn * 1000ULL,
                                   dllk_cbTimerSwitchOver, 0L, FALSE);
         }
     }


### PR DESCRIPTION
The switch-over timer must be created/modified only if Standby Managing
Node is active. Otherwise (on Active Managing Node) no free high-res timer
might exist. There the switch-over timer is properly started on NMT state
change.

Additionally, the delayed switch-over time must be used in PreOp2 and
ReadyToOp.

Signed-off-by: Daniel Krueger <daniel.krueger@systec-electronic.com>